### PR TITLE
add OpenAPI documentation with drf-spectacular

### DIFF
--- a/backend/todo_project/settings.py
+++ b/backend/todo_project/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'rest_framework',
+    'drf_spectacular',
 
     'todo_app',
 ]
@@ -124,3 +125,14 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Todo API',
+    'DESCRIPTION': 'API для управления todo задачами',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+}

--- a/backend/todo_project/urls.py
+++ b/backend/todo_project/urls.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from todo_app.views import TaskViewSet
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 router = DefaultRouter()
 router.register(r'tasks', TaskViewSet)
@@ -9,4 +10,7 @@ router.register(r'tasks', TaskViewSet)
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include(router.urls)),
+
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/docs/', SpectacularSwaggerView.as_view(), name='swagger-ui')
 ]


### PR DESCRIPTION
- Add basic API views for OpenAPI documentation
- Impemented filtering by 'completed'
<img width="2558" height="1275" alt="Снимок экрана 2025-09-18 202826" src="https://github.com/user-attachments/assets/8110301e-8e09-4d4f-8958-569359c89071" />
